### PR TITLE
feat: OrderStatus Enum 및 Order 도메인 클래스 작성 (#1)

### DIFF
--- a/src/main/java/com/humuson/orderintegration/domain/Order.java
+++ b/src/main/java/com/humuson/orderintegration/domain/Order.java
@@ -1,0 +1,33 @@
+package com.humuson.orderintegration.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Order {
+    @NotBlank(message = "주문 ID는 필수입니다")
+    private String orderId;
+
+    @NotBlank(message = "고객명은 필수입니다")
+    private String customerName;
+
+    @NotNull(message = "주문 날짜는 필수입니다")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime orderDate;
+
+    @NotNull(message = "주문 상태는 필수입니다")
+    private OrderStatus status;
+
+    private String description;
+
+}

--- a/src/main/java/com/humuson/orderintegration/domain/OrderStatus.java
+++ b/src/main/java/com/humuson/orderintegration/domain/OrderStatus.java
@@ -1,0 +1,18 @@
+package com.humuson.orderintegration.domain;
+
+public enum OrderStatus {
+    PROCESSING("처리 중"),
+    SHIPPING("배송 중"),
+    COMPLETED("완료"),
+    CANCELLED("취소");
+
+    private final String description;
+
+    OrderStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}


### PR DESCRIPTION
## 개요
주문 처리 및 외부 시스템 연동을 위한 핵심 도메인 클래스인 Order를 정의, 주문 상태를 나타내는 OrderStatus enum 추가

## 주요 변경 사항
- OrderStatus enum 추가

    - 주문 상태를 나타내는 PROCESSING, SHIPPING, COMPLETED, CANCELLED 네 가지 상태 정의
    - 각 상태에 대해 한글 설명 필드(description) 제공

- Order 클래스 추가

    - 주문 ID, 고객명, 주문일자, 주문 상태, 주문 설명 필드 포함
    - Bean Validation을 위한 제약 조건 설정
    - orderDate에 대해 Jackson 날짜 포맷 지정 (yyyy-MM-dd HH:mm:ss)

## 📎 관련 이슈

- Closes #1 