### PR TITLE
feat: 외부 시스템 Mock API 작성 및 Swagger 설정

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ src/
 │   │       │   │   └── ApiResponse.java
 │   │       │   └── OrderIntegrationController.java
 │   │       ├── external/
-│   │       │   ├── ExternalSystemMockController.java
+│   │       │   └── ExternalSystemMockController.java
 │   │       └── config/
 │   │           ├── IntegrationConfig.java
 │   │           └── SwaggerConfig.java
@@ -442,7 +442,6 @@ curl http://localhost:8080/api/orders
     }
     ```
 
-
 **주문 데이터 Export (내부 → 외부 시스템 전송)**
 
 1. 단일 주문 Export
@@ -483,6 +482,13 @@ curl http://localhost:8080/api/orders
     - GET `/api/orders/EXT-ORDER-001`
 3. 상태별 조회
     - GET `/api/orders/status/COMPLETED`
+
+| API 설명                     | 내부 로그 스크린샷                                                                                |
+|----------------------------|-------------------------------------------------------------------------------------------|
+| 주문 요청 (GET `/orders`)      | ![스크린샷1](https://github.com/user-attachments/assets/c1e4496b-fa7f-4fb0-9541-c43335ec5bd9) |
+| 단일 주문 전송 (POST `/orders`)  | ![스크린샷2](https://github.com/user-attachments/assets/551b2b10-6e0e-4df5-9637-24cb9611f3cd) |
+| 복수 주문 전송 (POST `/orders`)  | ![스크린샷3](https://github.com/user-attachments/assets/c87e732e-cec7-47c4-b534-a55a3b3edb4b) |
+| 지연 응답 (GET `/orders/slow`) | ![스크린샷4](https://github.com/user-attachments/assets/4e05da21-7a66-44da-a025-3a3e5ac7d922) |
 
 ## 확장성 고려사항
 

--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ curl http://localhost:8080/api/orders
     }
     ```
 
-`주문 조회`
+**주문 조회**
 
 1. 전체 주문 조회
     - GET `/api/orders`

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     // 트랜잭션 어노테이션 사용을 위한 의존성
     implementation 'org.springframework:spring-tx'
 
+    // Swagger
+    implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9"
+
     // Test Dependencies
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/humuson/orderintegration/config/SwaggerConfig.java
+++ b/src/main/java/com/humuson/orderintegration/config/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package com.humuson.orderintegration.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Order Integration System API")
+                .description("Swagger UI")
+                .version("v1.0.0");
+    }
+}

--- a/src/main/java/com/humuson/orderintegration/external/ExternalSystemMockController.java
+++ b/src/main/java/com/humuson/orderintegration/external/ExternalSystemMockController.java
@@ -1,0 +1,174 @@
+package com.humuson.orderintegration.external;
+
+import com.humuson.orderintegration.client.dto.ExternalSystemResponse;
+import com.humuson.orderintegration.client.dto.OrderRequest;
+import com.humuson.orderintegration.client.dto.OrderResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 외부 시스템 테스트용 컨트롤러로, 실제 외부 시스템의 동작을 시뮬레이션한다.
+ */
+@RestController
+@RequestMapping("/external-system")
+public class ExternalSystemMockController {
+
+    private static final Logger logger = LoggerFactory.getLogger(ExternalSystemMockController.class);
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    /**
+     * 외부 시스템에서 주문 데이터를 제공하는 엔드포인트 (Import 테스트용)
+     * GET /external-system/orders
+     */
+    @GetMapping("/orders")
+    public ResponseEntity<List<OrderRequest>> getOrders() {
+        logger.info("외부 시스템: 주문 데이터 요청 수신");
+
+        // 테스트용 주문 데이터 생성
+        List<OrderRequest> orders = Arrays.asList(
+                OrderRequest.builder()
+                        .orderId("EXT-ORDER-001")
+                        .customerName("김철수")
+                        .orderDate("2024-01-15 09:30:00")
+                        .status("PROCESSING")
+                        .description("외부 시스템 주문 1")
+                        .build(),
+                OrderRequest.builder()
+                        .orderId("EXT-ORDER-002")
+                        .customerName("이영희")
+                        .orderDate("2024-01-15 10:15:00")
+                        .status("SHIPPING")
+                        .description("외부 시스템 주문 2")
+                        .build(),
+                OrderRequest.builder()
+                        .orderId("EXT-ORDER-003")
+                        .customerName("박민수")
+                        .orderDate("2024-01-15 11:00:00")
+                        .status("COMPLETED")
+                        .description("외부 시스템 주문 3")
+                        .build()
+        );
+
+        logger.info("외부 시스템: {} 건의 주문 데이터 전송", orders.size());
+        return ResponseEntity.ok(orders);
+    }
+
+    /**
+     * 외부 시스템에서 주문 데이터를 수신하는 엔드포인트 (Export 테스트용)
+     * POST /external-system/orders
+     */
+    @PostMapping("/orders")
+    public ResponseEntity<ExternalSystemResponse<String>> receiveOrders(
+            @RequestBody List<OrderResponse> orders) {
+
+        logger.info("외부 시스템: {} 건의 주문 데이터 수신", orders.size());
+
+        // 수신된 주문 데이터 로깅
+        for (OrderResponse order : orders) {
+            logger.info("수신된 주문: ID={}, 고객명={}, 상태={}, 처리시간={}",
+                    order.getOrderId(),
+                    order.getCustomerName(),
+                    order.getStatus(),
+                    order.getProcessedAt());
+        }
+
+        // 성공 응답 반환
+        ExternalSystemResponse<String> response = ExternalSystemResponse.<String>builder()
+                .success(true)
+                .message(orders.size() + "건의 주문 데이터를 성공적으로 수신했습니다.")
+                .data("처리 완료")
+                .timestamp(LocalDateTime.now().format(DATE_FORMATTER))
+                .build();
+
+        logger.info("외부 시스템: 주문 데이터 처리 완료");
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 네트워크 오류 시뮬레이션 엔드포인트
+     * GET /external-system/orders/error
+     */
+    @GetMapping("/orders/error")
+    public ResponseEntity<String> simulateError() {
+        logger.warn("외부 시스템: 오류 시뮬레이션 - 500 Internal Server Error");
+        return ResponseEntity.status(500).body("External System Error: Database connection failed");
+    }
+
+    /**
+     * 지연 응답 시뮬레이션 엔드포인트
+     * GET /external-system/orders/slow
+     */
+    @GetMapping("/orders/slow")
+    public ResponseEntity<List<OrderRequest>> getOrdersWithDelay() {
+        logger.info("외부 시스템: 지연 응답 시뮬레이션 시작");
+
+        try {
+            // 5초 지연
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.error("지연 시뮬레이션 중 인터럽트 발생", e);
+        }
+
+        List<OrderRequest> orders = Arrays.asList(
+                OrderRequest.builder()
+                        .orderId("SLOW-ORDER-001")
+                        .customerName("지연테스트")
+                        .orderDate("2024-01-15 12:00:00")
+                        .status("PROCESSING")
+                        .description("지연 응답 테스트 주문")
+                        .build()
+        );
+
+        logger.info("외부 시스템: 지연 응답 완료");
+        return ResponseEntity.ok(orders);
+    }
+
+    /**
+     * 잘못된 데이터 형식 시뮬레이션 엔드포인트
+     * GET /external-system/orders/invalid
+     */
+    @GetMapping("/orders/invalid")
+    public ResponseEntity<String> getInvalidData() {
+        logger.warn("외부 시스템: 잘못된 데이터 형식 반환");
+        return ResponseEntity.ok("{ \"invalid\": \"json format\" }");
+    }
+
+    /**
+     * 빈 데이터 시뮬레이션 엔드포인트
+     * GET /external-system/orders/empty
+     */
+    @GetMapping("/orders/empty")
+    public ResponseEntity<List<OrderRequest>> getEmptyOrders() {
+        logger.info("외부 시스템: 빈 주문 데이터 반환");
+        return ResponseEntity.ok(Arrays.asList());
+    }
+
+    /**
+     * 부분적 실패 시뮬레이션 엔드포인트
+     * POST /external-system/orders/partial-fail
+     */
+    @PostMapping("/orders/partial-fail")
+    public ResponseEntity<ExternalSystemResponse<String>> receiveOrdersWithPartialFailure(
+            @RequestBody List<OrderResponse> orders) {
+
+        logger.warn("외부 시스템: 부분적 실패 시뮬레이션");
+
+        ExternalSystemResponse<String> response = ExternalSystemResponse.<String>builder()
+                .success(false)
+                .message("일부 주문 처리에 실패했습니다. 성공: " + (orders.size() - 1) + "건, 실패: 1건")
+                .data("부분적 처리 완료")
+                .timestamp(LocalDateTime.now().format(DATE_FORMATTER))
+                .build();
+
+        return ResponseEntity.status(207).body(response); // 207 Multi-Status
+    }
+
+}


### PR DESCRIPTION
## 개요
외부 시스템 Mock API 컨트롤러 OrderIntegrationController 작성, Swagger 설정

## 주요 변경 사항

1. ExternalSystemMockController 구현
    - 외부 시스템 Mock API 컨트롤러
    - 테스트용 시뮬레이션 API 작성
        - GET `/external-system/orders` : 샘플 주문 데이터 반환 (Import 테스트용)
        - POST `/external-system/orders` : 주문 수신 처리 (Export 테스트용)
        - GET `/external-system/orders/error` : 500 에러 시뮬레이션
        - GET `/external-system/orders/slow` : 5초 지연 응답 시뮬레이션
        - GET `/external-system/orders/invalid` : 잘못된 JSON 형식 반환
        - GET `/external-system/orders/empty` : 빈 리스트 반환
        - POST `/external-system/orders/partial-fail` : 부분 실패 (207 Multi-Status) 시뮬레이션
2. Swagger 설정 추가
    - `springdoc-openapi-starter-webmvc-ui` 의존성 추가
    - 접속 경로: `http://localhost:8080/swagger-ui/index.html`

## 스크린샷
<img width="927" height="107" alt="스크린샷 2025-07-25 132152" src="https://github.com/user-attachments/assets/c1e4496b-fa7f-4fb0-9541-c43335ec5bd9" />
<img width="984" height="104" alt="스크린샷 2025-07-25 132650" src="https://github.com/user-attachments/assets/551b2b10-6e0e-4df5-9637-24cb9611f3cd" />
<img width="958" height="123" alt="스크린샷 2025-07-25 133815" src="https://github.com/user-attachments/assets/c87e732e-cec7-47c4-b534-a55a3b3edb4b" />
<img width="958" height="104" alt="스크린샷 2025-07-25 135728" src="https://github.com/user-attachments/assets/4e05da21-7a66-44da-a025-3a3e5ac7d922" />

## 📎 관련 이슈

- Closes #11 